### PR TITLE
Initial infra modification and creation with vpc, ec2, sg resources

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,6 +1,4 @@
-provider "aws" {
-  region = "us-east-2"
-}
+# main.tf (Root Module)
 
 module "vpc" {
   source          = "../../modules/vpc"
@@ -8,4 +6,19 @@ module "vpc" {
   main_vpc_cidr   = var.main_vpc_cidr
   public_subnets  = var.public_subnets
   private_subnets = var.private_subnets
+}
+
+module "security_group" {
+  source        = "../../modules/security_group"
+  vpc_id        = module.vpc.vpc_id
+}
+
+module "ec2" {
+  source            = "../../modules/ec2"
+  region            = var.region
+  ec2_ami_id        = var.ec2_ami_id
+  ec2_instance_type = var.ec2_instance_type
+  security_group_id = module.security_group.security_group_id
+  subnet_id         = module.vpc.public_subnet_id
+  key_name          = var.key_name  # Pass key_name to the EC2 module
 }

--- a/infra/terraform/environments/dev/output.tf
+++ b/infra/terraform/environments/dev/output.tf
@@ -1,0 +1,31 @@
+# output.tf (Root Module)
+
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnet_id" {
+  description = "The ID of the public subnet"
+  value       = module.vpc.public_subnet_id
+}
+
+output "private_subnet_id" {
+  description = "The ID of the private subnet"
+  value       = module.vpc.private_subnet_id
+}
+
+output "security_group_id" {
+  description = "The ID of the security group"
+  value       = module.security_group.security_group_id
+}
+
+output "ec2_instance_id" {
+  description = "The ID of the EC2 instance"
+  value       = module.ec2.ec2_instance_id
+}
+
+output "ec2_public_ip" {
+  description = "The public IP address of the EC2 instance"
+  value       = module.ec2.ec2_public_ip
+}

--- a/infra/terraform/environments/dev/terraform.tfvars
+++ b/infra/terraform/environments/dev/terraform.tfvars
@@ -1,4 +1,9 @@
-region = "us-east-1"
-main_vpc_cidr   = "10.0.0.0/24"
-public_subnets  = "10.0.0.128/26"
-private_subnets = "10.0.0.192/26"
+# terraform.tfvars (Root Module)
+
+region             = "us-east-2"
+main_vpc_cidr      = "10.0.0.0/24"
+public_subnets     = "10.0.0.0/26"
+private_subnets    = "10.0.0.64/26"
+ec2_ami_id         = "ami-0ea3c35c5c3284d82"  # Example AMI ID, replace with your actual AMI ID
+ec2_instance_type  = "t2.micro"      # Example instance type
+key_name           = "eCom-ohio"   # Replace with your key pair name

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,4 +1,36 @@
-variable "region" {}
-variable "main_vpc_cidr" {}
-variable "public_subnets" {}
-variable "private_subnets" {}
+# variables.tf (Root Module)
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "main_vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "public_subnets" {
+  description = "CIDR block for the public subnets"
+  type        = string
+}
+
+variable "private_subnets" {
+  description = "CIDR block for the private subnets"
+  type        = string
+}
+
+variable "ec2_ami_id" {
+  description = "AMI ID for the EC2 instance"
+  type        = string
+}
+
+variable "ec2_instance_type" {
+  description = "EC2 instance type"
+  type        = string
+}
+
+variable "key_name" {
+  description = "The SSH key pair name to use for EC2 instances"
+  type        = string
+}


### PR DESCRIPTION
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.ec2.aws_instance.ec2_instance will be created
  + resource "aws_instance" "ec2_instance" {
      + ami                                  = "ami-0ea3c35c5c3284d82"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = "eCom-ohio"
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "eCom-EC2-Instance"
        }
      + tags_all                             = {
          + "Name" = "eCom-EC2-Instance"
        }
      + tenancy                              = (known after apply)
      + user_data                            = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification {
          + capacity_reservation_preference = (known after apply)

          + capacity_reservation_target {
              + capacity_reservation_id                 = (known after apply)
              + capacity_reservation_resource_group_arn = (known after apply)
            }
        }

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + maintenance_options {
          + auto_recovery = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
          + instance_metadata_tags      = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_card_index    = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

  # module.security_group.aws_security_group.ec2_sg will be created
  + resource "aws_security_group" "ec2_sg" {
      + arn                    = (known after apply)
      + description            = "Allow inbound SSH and HTTP access"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 22
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 22
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 80
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 80
            },
        ]
      + name                   = "eCom-Security-Group"
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Name" = "eCom-SG"
        }
      + tags_all               = {
          + "Name" = "eCom-SG"
        }
      + vpc_id                 = (known after apply)
    }

  # module.vpc.aws_internet_gateway.IGW will be created
  + resource "aws_internet_gateway" "IGW" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags     = {
          + "Name" = "eCom-IGW"
        }
      + tags_all = {
          + "Name" = "eCom-IGW"
        }
      + vpc_id   = (known after apply)
    }

  # module.vpc.aws_route_table.PrivateRT will be created
  + resource "aws_route_table" "PrivateRT" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = [
          + {
              + carrier_gateway_id         = ""
              + cidr_block                 = "0.0.0.0/0"
              + core_network_arn           = ""
              + destination_prefix_list_id = ""
              + egress_only_gateway_id     = ""
              + gateway_id                 = (known after apply)
              + instance_id                = ""
              + ipv6_cidr_block            = ""
              + local_gateway_id           = ""
              + nat_gateway_id             = ""
              + network_interface_id       = ""
              + transit_gateway_id         = ""
              + vpc_endpoint_id            = ""
              + vpc_peering_connection_id  = ""
            },
        ]
      + tags             = {
          + "Name" = "eCom-NAT-RT"
        }
      + tags_all         = {
          + "Name" = "eCom-NAT-RT"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table.PublicRT will be created
  + resource "aws_route_table" "PublicRT" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = [
          + {
              + carrier_gateway_id         = ""
              + cidr_block                 = "0.0.0.0/0"
              + core_network_arn           = ""
              + destination_prefix_list_id = ""
              + egress_only_gateway_id     = ""
              + gateway_id                 = (known after apply)
              + instance_id                = ""
              + ipv6_cidr_block            = ""
              + local_gateway_id           = ""
              + nat_gateway_id             = ""
              + network_interface_id       = ""
              + transit_gateway_id         = ""
              + vpc_endpoint_id            = ""
              + vpc_peering_connection_id  = ""
            },
        ]
      + tags             = {
          + "Name" = "eCom-IGW-RT"
        }
      + tags_all         = {
          + "Name" = "eCom-IGW-RT"
        }
      + vpc_id           = (known after apply)
    }

  # module.vpc.aws_route_table_association.PrivateRTassociation will be created
  + resource "aws_route_table_association" "PrivateRTassociation" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_route_table_association.PublicRTassociation will be created
  + resource "aws_route_table_association" "PublicRTassociation" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # module.vpc.aws_subnet.privatesubnets will be created
  + resource "aws_subnet" "privatesubnets" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-2b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.0.64/26"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "eCom-Private-Subnet"
        }
      + tags_all                                       = {
          + "Name" = "eCom-Private-Subnet"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_subnet.publicsubnets will be created
  + resource "aws_subnet" "publicsubnets" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-2a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.0.0/26"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "eCom-Public-Subnet"
        }
      + tags_all                                       = {
          + "Name" = "eCom-Public-Subnet"
        }
      + vpc_id                                         = (known after apply)
    }

  # module.vpc.aws_vpc.Main will be created
  + resource "aws_vpc" "Main" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/24"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Name" = "eCom-VPC"
        }
      + tags_all                             = {
          + "Name" = "eCom-VPC"
        }
    }

Plan: 10 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ec2_instance_id   = (known after apply)
  + ec2_public_ip     = (known after apply)
  + private_subnet_id = (known after apply)
  + public_subnet_id  = (known after apply)
  + security_group_id = (known after apply)
  + vpc_id            = (known after apply)
```